### PR TITLE
New breakpoints mediaQuery management

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -161,7 +161,6 @@ class App extends Component {
 						uiLang={settings.config.uiLang}
 						filterType={settings.config.filterType}
 						actionType={settings.config.actionType}
-						condensed={this.state.mobile}
 						showOnboarding={this.showOnboarding}
 						showFeedback={this.showFeedback}
 						showFlag={this.showFlag}

--- a/src/components/Controls/Button.js
+++ b/src/components/Controls/Button.js
@@ -2,6 +2,9 @@ import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 
+import { useBreakpoint } from "../../helpers/hooks";
+import breakpoint from "../../helpers/breakpoint";
+
 const StyledButton = styled.button`
 	display: inline-flex;
 
@@ -36,10 +39,6 @@ const StyledButton = styled.button`
 	`}
 
 	${props =>
-		props.condensed &&
-		`
-	`}
-	${props =>
 		props.iconOnly &&
 		`
 		width: auto;
@@ -67,33 +66,33 @@ const StyledText = styled.span`
 `;
 
 const StyledIcon = styled.img`
-	width: 25px;
-	height: 25px;
+	width: 20px;
+	height: 20px;
 
 	${props => props.active && "filter: invert(100%);"}
 	${props => props.disabled && "filter: invert(50%);"}
 
-	${props =>
-		props.condensed &&
-		`
-		width: 20px;
-		height: 20px;
+	${breakpoint.min.l`
+		width: 25px;
+		height: 25px;
 	`}
 `;
 
 function Button(props) {
-	const { label, active, disabled, condensed, iconOnly, href, icon, glyphicon, className, onClick } = props;
+	const { label, active, disabled, iconOnly, href, icon, glyphicon, className, onClick } = props;
+
+	const isDesktop = useBreakpoint("l");
 
 	const linkProps = { as: "a", href, target: "_blank", rel: "noopener noreferrer" };
 	const buttonProps = { as: "button", onClick };
-	const displayText = (condensed && !iconOnly) || !condensed;
+	const displayText = (!isDesktop && !iconOnly) || isDesktop;
 
-	if (condensed && !icon && !glyphicon) {
+	if (!isDesktop && !icon && !glyphicon) {
 		return null;
 	}
 
 	const iconElement = icon ? (
-		<StyledIcon src={icon} active={active} disabled={disabled} condensed={condensed} />
+		<StyledIcon src={icon} active={active} disabled={disabled} />
 	) : (
 		<i className={`glyphicon glyphicon-${glyphicon}`}></i>
 	);
@@ -103,7 +102,6 @@ function Button(props) {
 			{...(href ? linkProps : buttonProps)}
 			active={active}
 			disabled={disabled}
-			condensed={condensed}
 			iconOnly={iconOnly}
 			className={className}
 		>
@@ -116,7 +114,6 @@ function Button(props) {
 Button.defaults = {
 	label: null,
 	active: false,
-	condensed: false,
 	iconOnly: false,
 	disabled: false,
 	href: null,
@@ -129,7 +126,6 @@ Button.defaults = {
 Button.propTypes = {
 	label: PropTypes.string,
 	active: PropTypes.bool,
-	condensed: PropTypes.bool,
 	iconOnly: PropTypes.bool,
 	disabled: PropTypes.bool,
 	href: PropTypes.string,

--- a/src/components/Controls/Controls.js
+++ b/src/components/Controls/Controls.js
@@ -2,26 +2,30 @@ import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 
-import consts from "../../consts.js";
-
 import Volume from "./Volume";
 import PlayerStatus from "./PlayerStatus";
 import PlayPause from "./PlayPause";
 
+import { useBreakpoint } from "../../helpers/hooks";
+
+import consts from "../../consts.js";
+
 const StyledControls = styled.div`
-  display: flex;
-  position: relative;
-  top: 100%;
-  height: 60px;
-  margin: -60px 0 0 0px;
-  z-index: 1000;
-  background: #eee;
-  align-items: center;
-  border-top: 2px solid #888;
+	display: flex;
+	position: relative;
+	top: 100%;
+	height: 60px;
+	margin: -60px 0 0 0px;
+	z-index: 1000;
+	background: #eee;
+	align-items: center;
+	border-top: 2px solid #888;
 `;
 
 function Controls(props) {
-	const { condensed, bsw, settings } = props;
+	const { bsw, settings } = props;
+
+	const isDesktop = useBreakpoint("l");
 
 	const togglePlayer = () => {
 		bsw.togglePlay();
@@ -37,14 +41,13 @@ function Controls(props) {
 	return (
 		<StyledControls>
 			<PlayPause playing={!isNaN(indexRadio)} onToggle={togglePlayer} />
-			<PlayerStatus radio={indexRadio} reducedVolume={reducedVolume} condensed={condensed} settings={settings} />
-			{!condensed && <Volume volume={settings.config.userVolume} onChange={handleVolumeChange} />}
+			<PlayerStatus radio={indexRadio} reducedVolume={reducedVolume} settings={settings} />
+			{isDesktop && <Volume volume={settings.config.userVolume} onChange={handleVolumeChange} />}
 		</StyledControls>
 	);
 }
 
 Controls.propTypes = {
-	condensed: PropTypes.bool.isRequired,
 	bsw: PropTypes.object.isRequired,
 	settings: PropTypes.object.isRequired
 };

--- a/src/components/Controls/PlayerStatus.js
+++ b/src/components/Controls/PlayerStatus.js
@@ -2,24 +2,30 @@ import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 
-const StyledText = styled.span`
-  font-size: 26px;
+import breakpoint from "../../helpers/breakpoint";
 
-  &.condensed {
-    font-size: 18px;
-  }
+const StyledText = styled.span`
+	font-size: 18px;
+
+	${breakpoint.min.l`
+		font-size: 22px
+	`}
+
+	${breakpoint.min.xl`
+		font-size: 26px
+	`}
 `;
 
 const noRadio = { fr: "Choisissez une radio à écouter", en: "Choose a radio to listen to" };
 const noSound = { fr: " (volume réduit)", en: " (muted)" };
 
 function PlayerStatus(props) {
-	const { condensed, radio, reducedVolume, settings } = props;
+	const { radio, reducedVolume, settings } = props;
 	const lang = settings.config.uiLang;
 
 	const text = isNaN(radio) ? noRadio[lang] : settings.radios[radio].name + (reducedVolume ? noSound[lang] : "");
 
-	return <StyledText className={condensed && "condensed"}>{text}</StyledText>;
+	return <StyledText>{text}</StyledText>;
 }
 
 PlayerStatus.defaults = {
@@ -29,7 +35,6 @@ PlayerStatus.defaults = {
 PlayerStatus.propTypes = {
 	radio: PropTypes.number.isRequired,
 	reducedVolume: PropTypes.bool,
-	condensed: PropTypes.bool.isRequired,
 	settings: PropTypes.object.isRequired
 };
 

--- a/src/components/Layout/GroupedButtons.js
+++ b/src/components/Layout/GroupedButtons.js
@@ -2,17 +2,20 @@ import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 
+import breakpoint from "../../helpers/breakpoint";
+
 // I didn't success to refer directly to the Button component. So I used `a` & `button` instead.
 const StyledGroupedButton = styled.div`
 	display: flex;
 	flex-direction: column;
-	${props => !props.condensed && "width: 240px;"}
-	/* align-items: center; */
+
+	${breakpoint.min.l`
+		width: 240px;
+	`}
 
 	& > button,
 	& > a {
-		${props => props.condensed &&
-			`
+		${breakpoint.max.l`
 			&:first-child {
 				border-bottom-left-radius: 0;
 				border-bottom-right-radius: 0;
@@ -33,10 +36,10 @@ const StyledGroupedButton = styled.div`
 `;
 
 function GroupedButtons(props) {
-	const { children, className, spaced, condensed } = props;
+	const { children, className, spaced } = props;
 
 	return (
-		<StyledGroupedButton className={className} spaced={spaced} condensed={condensed}>
+		<StyledGroupedButton className={className} spaced={spaced}>
 			{children}
 		</StyledGroupedButton>
 	);
@@ -44,14 +47,12 @@ function GroupedButtons(props) {
 
 GroupedButtons.defaults = {
 	className: null,
-	spaced: false,
-	condensed: false
+	spaced: false
 };
 
 GroupedButtons.propTypes = {
 	className: PropTypes.string,
 	spaced: PropTypes.bool,
-	condensed: PropTypes.bool,
 	children: PropTypes.array.isRequired
 };
 

--- a/src/components/Layout/Sidebar.js
+++ b/src/components/Layout/Sidebar.js
@@ -4,9 +4,12 @@ import styled from "styled-components";
 
 import Button from "../Controls/Button";
 
+import { useBreakpoint } from "../../helpers/hooks";
+import breakpoint from "../../helpers/breakpoint";
+
 const StyledSidebar = styled.div`
 	height: 100vh;
-	width: 350px;
+	width: 60px;
 
 	overflow: auto;
 
@@ -22,8 +25,11 @@ const StyledSidebar = styled.div`
 	/* allow to push player outside the screen on mobile with menu opened */
 	flex-shrink: 0;
 
-	${props => props.condensed && "width: 60px;"}
-	${props => props.condensed && props.opened && "width: 100%;"}
+	${props => props.opened && "width: 100%;"}
+
+	${breakpoint.min.l`
+		width: 350px;
+	`}
 `;
 
 // eslint-disable-next-line react/prop-types
@@ -64,32 +70,29 @@ const iconMenuOpened = "chevron-left";
 const iconMenuClosed = "menu-hamburger";
 
 function Sidebar(props) {
-	const { condensed, children } = props;
+	const { children } = props;
 
 	const [opened, setOpened] = useState(false);
+	const isDesktop = useBreakpoint("l");
 
 	const toggleOpened = () => setOpened(!opened);
 
 	return (
-		<StyledSidebar condensed={condensed} opened={opened}>
-			{condensed && (
-				<StyledToggle onClick={toggleOpened} condensed glyphicon={opened ? iconMenuOpened : iconMenuClosed} />
-			)}
-			{!condensed && <TopLogo />}
+		<StyledSidebar opened={opened}>
+			{!isDesktop && <StyledToggle onClick={toggleOpened} glyphicon={opened ? iconMenuOpened : iconMenuClosed} />}
+			{isDesktop && <TopLogo />}
 			{children(opened)}
-			{condensed && opened && <BottomLogo />}
+			{!isDesktop && opened && <BottomLogo />}
 		</StyledSidebar>
 	);
 }
 
 Sidebar.defaults = {
-	children: () => {},
-	condensed: false
+	children: () => {}
 };
 
 Sidebar.propTypes = {
-	children: PropTypes.func,
-	condensed: PropTypes.bool
+	children: PropTypes.func
 };
 
 export default Sidebar;

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -17,6 +17,9 @@ import ratings from "../img/ratings100.png";
 import flagIcon from "../img/flag2.svg";
 import donate from "../img/donate_2226736.svg";
 
+import { useBreakpoint } from "../helpers/hooks";
+import breakpoint from "../helpers/breakpoint";
+
 import consts from "../consts.js";
 
 const StyledTitle = styled.div`
@@ -26,8 +29,10 @@ const StyledTitle = styled.div`
 `;
 
 const StyledGroupedButtons = styled(GroupedButtons)`
-	margin-bottom: 40px;
-	${props => props.condensed && "margin-bottom: 10px;"}
+	margin-bottom: 10px;
+	${breakpoint.min.l`
+		margin-bottom: 40px;
+	`}
 `;
 const StyledButtons = styled(Button)`
 	margin-bottom: 15px;
@@ -40,7 +45,9 @@ const Hint = styled.div`
 `;
 
 function Menu(props) {
-	const { condensed, uiLang, filterType, actionType, bsw, showOnboarding, showFeedback, showFlag } = props;
+	const { uiLang, filterType, actionType, bsw, showOnboarding, showFeedback, showFlag } = props;
+
+	const isDesktop = useBreakpoint("l");
 
 	const filterTitle = { fr: "Je veux écouter\xa0:", en: "I want to listen to:" }[uiLang];
 
@@ -76,17 +83,16 @@ function Menu(props) {
 
 	// TODO: Migrate Sidebar isOpened argument to React.Context?
 	return (
-		<Sidebar condensed={condensed}>
+		<Sidebar>
 			{isOpened => (
 				<>
-					{(!condensed || isOpened) && <StyledTitle>{filterTitle}</StyledTitle>}
+					{(isDesktop || isOpened) && <StyledTitle>{filterTitle}</StyledTitle>}
 
-					<StyledGroupedButtons condensed={condensed}>
+					<StyledGroupedButtons>
 						<Button
 							label={musicBtnLabel}
 							icon={musicIcon}
 							iconOnly={!isOpened}
-							condensed={condensed}
 							active={filterType === consts.FILTER_MUSIC}
 							onClick={setFilterMusic}
 						/>
@@ -94,7 +100,6 @@ function Menu(props) {
 							label={speechBtnLabel}
 							icon={speechIcon}
 							iconOnly={!isOpened}
-							condensed={condensed}
 							active={filterType === consts.FILTER_SPEECH}
 							onClick={setFilterSpeech}
 						/>
@@ -102,20 +107,18 @@ function Menu(props) {
 							label={adsBtnLabel}
 							icon={adsIcon}
 							iconOnly={!isOpened}
-							condensed={condensed}
 							active={filterType === consts.FILTER_OFF}
 							onClick={setFilterOff}
 						/>
 					</StyledGroupedButtons>
 
-					{(!condensed || isOpened) && <StyledTitle>{actionTitle}</StyledTitle>}
+					{(isDesktop || isOpened) && <StyledTitle>{actionTitle}</StyledTitle>}
 
-					<StyledGroupedButtons condensed={condensed}>
+					<StyledGroupedButtons>
 						<Button
 							label={muteBtnLabel}
 							icon={mute}
 							iconOnly={!isOpened}
-							condensed={condensed}
 							active={actionType === consts.ACTION_MUTE}
 							onClick={setActionMute}
 							disabled={filterType === consts.FILTER_OFF}
@@ -125,7 +128,6 @@ function Menu(props) {
 							label={podiumBtnLabel}
 							icon={podium}
 							iconOnly={!isOpened}
-							condensed={condensed}
 							active={actionType === consts.ACTION_PODIUM}
 							onClick={setActionPodium}
 							disabled={filterType === consts.FILTER_OFF}
@@ -135,19 +137,17 @@ function Menu(props) {
 							label={roundaboutBtnLabel}
 							icon={roundabout}
 							iconOnly={!isOpened}
-							condensed={condensed}
 							active={actionType === consts.ACTION_ROUNDABOUT}
 							onClick={setActionRoundabout}
 							disabled={filterType === consts.FILTER_OFF}
 						/>
 					</StyledGroupedButtons>
 
-					<GroupedButtons spaced={true} condensed={condensed}>
+					<GroupedButtons spaced={true}>
 						<StyledButtons
 							icon={wand}
 							label={settingsBtnLabel}
 							iconOnly={!isOpened}
-							condensed={condensed}
 							onClick={showOnboarding}
 						/>
 
@@ -155,7 +155,6 @@ function Menu(props) {
 							icon={flagIcon}
 							label={bugBtnLabel}
 							iconOnly={!isOpened}
-							condensed={condensed}
 							onClick={showFlag}
 						/>
 
@@ -163,7 +162,6 @@ function Menu(props) {
 							icon={ratings}
 							label={suggestBtnLabel}
 							iconOnly={!isOpened}
-							condensed={condensed}
 							onClick={showFeedback}
 						/>
 
@@ -171,12 +169,11 @@ function Menu(props) {
 							icon={donate}
 							label={donateBtnLabel}
 							iconOnly={!isOpened}
-							condensed={condensed}
 							href={`https://${uiLang}.liberapay.com/asto/donate`}
 						/>
 					</GroupedButtons>
 
-					{condensed && isOpened && <Hint>{hintLabel}</Hint>}
+					{!isDesktop && isOpened && <Hint>{hintLabel}</Hint>}
 				</>
 			)}
 		</Sidebar>
@@ -186,7 +183,6 @@ function Menu(props) {
 Menu.defaults = {};
 
 Menu.propTypes = {
-	condensed: PropTypes.bool.isRequired,
 	uiLang: PropTypes.string.isRequired,
 	filterType: PropTypes.number.isRequired,
 	actionType: PropTypes.number.isRequired,
@@ -199,7 +195,6 @@ Menu.propTypes = {
 export default React.memo(Menu, (prev, next) => {
 	// Only those props can rerender this component!
 	return (
-		prev.condensed === next.condensed &&
 		prev.uiLang === next.uiLang &&
 		prev.filterType === next.filterType &&
 		prev.actionType === next.actionType

--- a/src/consts.js
+++ b/src/consts.js
@@ -40,6 +40,12 @@ const consts = {
 	COUNTRIES: ["France", "Argentina", "Belgium", "Canada", "Finland", "Germany", "Greece", "Italy", "Netherlands", "New Zealand", "Slovakia", "Spain", "Switzerland", "United Kingdom", "Uruguay"],
 	MIMETYPES: { "mp3": "audio/mp3", "ogg":"audio/ogg", "aac": "audio/mp4", "m3u8": "application/x-mpegURL" },
 
+	breakpoints: {
+		m: 768,
+		l: 992,
+		xl: 1200,
+	},
+
 	getStatusColor: function(status) {
 		switch(status) {
 			case this.STATUS_AD: return this.COLOR_ADS;

--- a/src/helpers/breakpoint.js
+++ b/src/helpers/breakpoint.js
@@ -1,0 +1,25 @@
+import { css } from "styled-components";
+
+import consts from "../consts";
+
+const { breakpoints } = consts;
+
+export const min = Object.keys(breakpoints).reduce((acc, label) => {
+	acc[label] = (...args) => css`
+		@media (min-width: ${breakpoints[label]}px) {
+			${css(...args)};
+		}
+	`;
+	return acc;
+}, {});
+
+export const max = Object.keys(breakpoints).reduce((acc, label) => {
+	acc[label] = (...args) => css`
+		@media (max-width: ${breakpoints[label] - 1}px) {
+			${css(...args)};
+		}
+	`;
+	return acc;
+}, {});
+
+export default { min, max };

--- a/src/helpers/hooks.js
+++ b/src/helpers/hooks.js
@@ -1,0 +1,23 @@
+import { useState, useEffect } from "react";
+
+import consts from "../consts";
+
+const { breakpoints } = consts;
+
+export function useBreakpoint(size) {
+	const mediaQuery = window.matchMedia(`(min-width: ${breakpoints[size]}px)`);
+
+	const [value, setValue] = useState(mediaQuery.matches);
+
+	useEffect(() => {
+		const handler = () => setValue(mediaQuery.matches);
+		mediaQuery.addListener(handler);
+		return () => mediaQuery.removeListener(handler);
+	}, []);
+
+	return value;
+}
+
+export default {
+	useBreakpoint
+};


### PR DESCRIPTION
We can now stop passing down `condensed` prop to all components:
- styled-component breakpoint helper: use media-query to style components
- React Hook `useBreakpoint`: use hook to watch breakpoint change events

`consts.js` file define 3 breakpoints usable by these two helpers:
```
breakpoints: {
    m: 768,
    l: 992,
    xl: 1200,
},
```
The old `condensed` breakpoint at 1000px have been replaced by the `l` breakpoint. 992px is a commonly recommended value.

Hook example:
```js
const isDesktop = useBreakpoint("l"); // Return true or false
```
StyledComponent example:
```js
const myStyledImg = styled.img`
   width: 20px;
   height: 20px;

   ${breakpoint.min.l`
      width: 25px;
      height: 25px;
   `}
`;
```

Cheers!